### PR TITLE
Use semver for nodejieba

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "~1.1.1"
   },
   "optionalDependencies": {
-    "nodejieba": "~1.2.2"
+    "nodejieba": "^1.3.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
`nodejieba@1.2.x` is not compatible with `io.js` v3.x:

```
npm install nodejieba@1.2
\
> nodejieba@1.2.2 install /Users/Chris/Workspace/pubu.im/pubu.im/node_modules/nodejieba
> node-gyp rebuild

  CXX(target) Release/obj.target/nodejieba/lib/index.o
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:6:
../node_modules/nan/nan.h:261:25: error: redefinition of '_NanEnsureLocal'
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
                        ^
../node_modules/nan/nan.h:256:25: note: previous definition is here
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Handle<T> val) {
                        ^
../node_modules/nan/nan.h:661:13: error: no member named 'smalloc' in namespace 'node'
    , node::smalloc::FreeCallback callback
      ~~~~~~^
../node_modules/nan/nan.h:672:12: error: no matching function for call to 'New'
    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
           ^~~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/node_buffer.h:31:40: note: candidate function not viable: no known
      conversion from 'uint32_t' (aka 'unsigned int') to 'enum encoding' for 3rd argument
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/Chris/.node-gyp/3.1.0/include/node/node_buffer.h:43:40: note: candidate function not viable: 2nd argument
      ('const char *') would lose const qualifier
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/Chris/.node-gyp/3.1.0/include/node/node_buffer.h:28:40: note: candidate function not viable: requires 2
      arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
                                       ^
/Users/Chris/.node-gyp/3.1.0/include/node/node_buffer.h:36:40: note: candidate function not viable: requires 5
      arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:6:
../node_modules/nan/nan.h:676:12: error: no viable conversion from 'v8::MaybeLocal<v8::Object>' to
      'v8::Local<v8::Object>'
    return node::Buffer::New(v8::Isolate::GetCurrent(), size);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:210:7: note: candidate constructor (the implicit copy constructor) not
      viable: no known conversion from 'v8::MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st
      argument
class Local {
      ^
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:210:7: note: candidate constructor (the implicit move constructor) not
      viable: no known conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
class Local {
      ^
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:214:13: note: candidate template ignored: could not match 'Local'
      against 'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:327:13: note: candidate template ignored: could not match 'S *' against
      'v8::MaybeLocal<v8::Object>'
  V8_INLINE Local(S* that)
            ^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:6:
../node_modules/nan/nan.h:683:26: error: no member named 'Use' in namespace 'node::Buffer'
    return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
           ~~~~~~~~~~~~~~^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:4:
In file included from /Users/Chris/.node-gyp/3.1.0/include/node/node.h:42:
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:221:5: error: assigning to 'v8::Primitive *volatile' from incompatible
      type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:414:12: note: in instantiation of function template specialization
      'v8::Local<v8::Primitive>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:4:
In file included from /Users/Chris/.node-gyp/3.1.0/include/node/node.h:42:
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:221:5: error: assigning to 'v8::Boolean *volatile' from incompatible
      type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:424:12: note: in instantiation of function template specialization
      'v8::Local<v8::Boolean>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(v8::True(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:4:
In file included from /Users/Chris/.node-gyp/3.1.0/include/node/node.h:42:
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:221:5: error: assigning to 'v8::Function *volatile' from incompatible
      type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1514:12: note: in instantiation of function template specialization
      'v8::Local<v8::Function>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(handle)->Get(kCallbackIndex)
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../lib/index.cpp:1:
In file included from ../lib/nodejieba.h:4:
In file included from ../lib/utils.h:4:
In file included from /Users/Chris/.node-gyp/3.1.0/include/node/node.h:42:
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:221:5: error: assigning to 'v8::Object *volatile' from incompatible
      type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/Chris/.node-gyp/3.1.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1632:12: note: in instantiation of function template specialization
      'v8::Local<v8::Object>::Local<v8::Value>' requested here
    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
9 errors generated.
make: *** [Release/obj.target/nodejieba/lib/index.o] Error 1
gyp ERR! build error
```

But v1.3.x does support `io.js` v3.x:

```
npm install nodejieba@1.3
-
> nodejieba@1.3.0 install /Users/Chris/Workspace/pubu.im/pubu.im/node_modules/nodejieba
> node-gyp rebuild

  CXX(target) Release/obj.target/nodejieba/lib/index.o
  CXX(target) Release/obj.target/nodejieba/lib/nodejieba.o
  SOLINK_MODULE(target) Release/nodejieba.node
ld: warning: object file (Release/obj.target/nodejieba/lib/index.o) was built for newer OSX version (10.7) than being linked (10.5)
ld: warning: object file (Release/obj.target/nodejieba/lib/nodejieba.o) was built for newer OSX version (10.7) than being linked (10.5)
nodejieba@1.3.0 node_modules/nodejieba
└── nan@2.0.5
```

Also, in normal case, we should use `^x.y.z' to specify version for semver compatible package.