### PR TITLE
Fix Travis CI build failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "0.12"
   - "iojs-1"
   - "iojs-2"
+  - "iojs-3"
 
 install:
   - npm install spm coveralls mocha
@@ -20,3 +21,15 @@ script:
 
 after_success:
   - cat coverage/lcov.info | node_modules/.bin/coveralls
+
+# nodejieba only support g++ 4.8
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
这事比较尴尬，`nodejieba` 对 `CXX` 组件有要求，OS 不带这个组件会安装失败，Ubuntu、OS X 目测默认是带了，因此我这边 build 一直是 OK 的，Travis CI 的环境可能比较干净，因此缺组件。