### PR TITLE
add "use strict" on file header

### DIFF
--- a/lib/web-pinyin.js
+++ b/lib/web-pinyin.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // 解压拼音库。
 // @param {Object} dict_combo, 压缩的拼音库。
 // @param {Object} 解压的拼音库。


### PR DESCRIPTION
Throw error when use webpack to build:

```
Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode (web-pinyin.js)
```

Fixed: add "use strict" on `web-pinyin.js`.