### PR TITLE
fix: 修复babel编译后的文件不支持ie8的问题

### DIFF
--- a/lib/pinyin.js
+++ b/lib/pinyin.js
@@ -184,27 +184,20 @@ class Pinyin {
     return String(pinyinA).localeCompare(pinyinB);
   }
 
-  static get STYLE_NORMAL () {
-    return PINYIN_STYLE.NORMAL;
-  }
-  static get STYLE_TONE () {
-    return PINYIN_STYLE.TONE;
-  }
-  static get STYLE_TONE2 () {
-    return PINYIN_STYLE.TONE2;
-  }
-  static get STYLE_TO3NE () {
-    return PINYIN_STYLE.TO3NE;
-  }
-  static get STYLE_INITIALS () {
-    return PINYIN_STYLE.INITIALS;
-  }
-  static get STYLE_FIRST_LETTER () {
-    return PINYIN_STYLE.FIRST_LETTER;
-  }
-  static get DEFAULT_OPTIONS () {
-    return DEFAULT_OPTIONS;
-  }
+  static STYLE_NORMAL = PINYIN_STYLE.NORMAL;
+
+  static STYLE_TONE = PINYIN_STYLE.TONE;
+
+  static STYLE_TONE2 = PINYIN_STYLE.TONE2;
+
+  static STYLE_TO3NE = PINYIN_STYLE.TO3NE;
+
+  static STYLE_INITIALS = PINYIN_STYLE.INITIALS;
+
+  static STYLE_FIRST_LETTER = PINYIN_STYLE.FIRST_LETTER;
+
+  static DEFAULT_OPTIONS = DEFAULT_OPTIONS;
+
 }
 
 module.exports = Pinyin;


### PR DESCRIPTION
现在代码实现中有get，set，导致编译后的文件带有ie8不兼容的get
```javascript
Object.defineProperty(a, 'b', {
    get: function () {
     ....
    }
})
```

这种代码没有找到在ie8下的兼容方式（es5-shim，babel-polyfill，core.js都不行）
所以使用了一种与目前代码实现等价的方式（虽然看起来没以前那么高大上）修复该问题。
修复后的代码，在经过babel编译后，可以兼容ie8