### PR TITLE
+ Param for String.localeCompare should be a string.

### DIFF
--- a/lib/pinyin.js
+++ b/lib/pinyin.js
@@ -181,7 +181,7 @@ class Pinyin {
   compare (hanA, hanB) {
     const pinyinA = this.convert(hanA, DEFAULT_OPTIONS);
     const pinyinB = this.convert(hanB, DEFAULT_OPTIONS);
-    return String(pinyinA).localeCompare(pinyinB);
+    return String(pinyinA).localeCompare(String(pinyinB));
   }
 
   static get STYLE_NORMAL () {


### PR DESCRIPTION
`String.localeCompare` 应该接受 `string` 类型, 而 `pinyinB` 为一个 `string[]`.