### PR TITLE
Allow phrase grouping

### DIFF
--- a/README-us_EN.md
+++ b/README-us_EN.md
@@ -51,8 +51,12 @@ console.log(pinyin("中心", {
 }));                            // [ [ 'zhōng', 'zhòng' ], [ 'xīn' ] ]
 console.log(pinyin("中心", {
   heteronym: true,              // Enable heteronym mode.
-  segment: true                 // Enable Chinese words eegmentation, fix most heteronym problem.
+  segment: true                 // Enable Chinese words segmentation, fix most heteronym problem.
 }));                            // [ [ 'zhōng' ], [ 'xīn' ] ]
+console.log(pinyin("我喜欢你", {
+  segment: true,                // Enable segmentation. Needed for grouping.
+  group: true                   // Group pinyin segments
+}));                            // [ [ [ 'wǒ' ] ], [ [ 'xǐ' ], [ 'huān' ] ], [ [ 'nǐ' ] ] ]
 console.log(pinyin("中心", {
   style: pinyin.STYLE_INITIALS, // Setting pinyin style.
   heteronym: true

--- a/README-us_EN.md
+++ b/README-us_EN.md
@@ -56,7 +56,7 @@ console.log(pinyin("中心", {
 console.log(pinyin("我喜欢你", {
   segment: true,                // Enable segmentation. Needed for grouping.
   group: true                   // Group pinyin segments
-}));                            // [ [ [ 'wǒ' ] ], [ [ 'xǐ' ], [ 'huān' ] ], [ [ 'nǐ' ] ] ]
+}));                            // [ [ 'wǒ' ], [ 'xǐhuān' ], [ 'nǐ' ] ]
 console.log(pinyin("中心", {
   style: pinyin.STYLE_INITIALS, // Setting pinyin style.
   heteronym: true

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ console.log(pinyin("中心", {
   heteronym: true,              // 启用多音字模式
   segment: true                 // 启用分词，以解决多音字问题。
 }));                            // [ [ 'zhōng' ], [ 'xīn' ] ]
+console.log(pinyin("我喜欢你", {
+  segment: true,                // 启用分词
+  group: true                   // 启用词组
+}));                            // [ [ [ 'wǒ' ] ], [ [ 'xǐ' ], [ 'huān' ] ], [ [ 'nǐ' ] ] ]
 console.log(pinyin("中心", {
   style: pinyin.STYLE_INITIALS, // 设置拼音风格
   heteronym: true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ console.log(pinyin("中心", {
 console.log(pinyin("我喜欢你", {
   segment: true,                // 启用分词
   group: true                   // 启用词组
-}));                            // [ [ [ 'wǒ' ] ], [ [ 'xǐ' ], [ 'huān' ] ], [ [ 'nǐ' ] ] ]
+}));                            // [ [ 'wǒ' ], [ 'xǐhuān' ], [ 'nǐ' ] ]
 console.log(pinyin("中心", {
   style: pinyin.STYLE_INITIALS, // 设置拼音风格
   heteronym: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,10 +34,14 @@ class NodePinyin extends Pinyin {
           nohans = ""; // reset non-chinese words.
         }
 
-        if (words.length === 1) {
-          pys = pys.concat(super.convert(words, options));
+        const newPys = words.length === 1
+          ? super.convert(words, options)
+          : this.phrases_pinyin(words, options);
+
+        if (options.group) {
+          pys.push(newPys);
         } else {
-          pys = pys.concat(this.phrases_pinyin(words, options));
+          pys = pys.concat(newPys);
         }
 
       } else {
@@ -47,6 +51,9 @@ class NodePinyin extends Pinyin {
 
     // 清理最后的非中文字符串。
     if(nohans.length > 0){
+      if (options.group) {
+        nohans = [nohans];
+      }
       pys.push([nohans]);
       nohans = ""; // reset non-chinese words.
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ class NodePinyin extends Pinyin {
           : this.phrases_pinyin(words, options);
 
         if (options.group) {
-          pys.push(newPys);
+          pys.push(groupPhrases(newPys));
         } else {
           pys = pys.concat(newPys);
         }
@@ -51,9 +51,6 @@ class NodePinyin extends Pinyin {
 
     // 清理最后的非中文字符串。
     if(nohans.length > 0){
-      if (options.group) {
-        nohans = [nohans];
-      }
       pys.push([nohans]);
       nohans = ""; // reset non-chinese words.
     }
@@ -101,6 +98,18 @@ function segment(hans) {
   // 词语拼音库。
   PHRASES_DICT = PHRASES_DICT || require("../data/phrases-dict");
   return jieba.cutSmall(hans, 4);
+}
+
+function groupPhrases(phrases) {
+  if (phrases.length === 1) {
+    return phrases[0];
+  }
+
+  const grouped = phrases.reduce(function(phrase, pys) {
+    return phrase + pys[0];
+  }, "");
+
+  return [grouped];
 }
 
 const pinyin = new NodePinyin(PINYIN_DICT);

--- a/tests/test.js
+++ b/tests/test.js
@@ -273,12 +273,12 @@ describe("pinyin group", function() {
   it("groups segments", function () {
     const han = "我喜欢你";
     const py = pinyin(han, {segment: true, group: true, heteronym: true});
-    expect(py).to.eql([[["wǒ"]], [["xǐ"], ["huān"]], [["nǐ"]]]);
+    expect(py).to.eql([["wǒ"], ["xǐhuān"], ["nǐ"]]);
   });
 
   it("groups segments with heteronyms", function() {
     const han = "我都喜欢";
     const py = pinyin(han, {segment: true, group: true, heteronym: true});
-    expect(py).to.eql([[["wǒ"]], [["dū", "dōu"]], [["xǐ"], ["huān"]]]);
+    expect(py).to.eql([["wǒ"], ["dū", "dōu"], ["xǐhuān"]]);
   });
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -268,3 +268,17 @@ describe("pinyin.compare", function() {
     expect(sortedData).to.eql("排我序要".split(""));
   });
 });
+
+describe("pinyin group", function() {
+  it("groups segments", function () {
+    const han = "我喜欢你";
+    const py = pinyin(han, {segment: true, group: true, heteronym: true});
+    expect(py).to.eql([[["wǒ"]], [["xǐ"], ["huān"]], [["nǐ"]]]);
+  });
+
+  it("groups segments with heteronyms", function() {
+    const han = "我都喜欢";
+    const py = pinyin(han, {segment: true, group: true, heteronym: true});
+    expect(py).to.eql([[["wǒ"]], [["dū", "dōu"]], [["xǐ"], ["huān"]]]);
+  });
+});


### PR DESCRIPTION
This change adds a `group` option, which will group pinyin phrases
together. This is useful if you want to generate more readable pinyin.

```
我喜欢你
wǒ xǐhuān nǐ
```