### PR TITLE
Ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ npm-debug.log
 spm_modules/
 tools/dict/error.log
 coverage/
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This change ignores the `npm` `package-lock.json` and `yarn` `yarn.lock`
files, which shouldn't be included in packages anyway.