### PR TITLE
perf: replace nodejieba with @node-rs/jieba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ os:
 language: node_js
 
 node_js:
-  - "5"
-  - "9"
+  - "8"
   - "10"
-  - "11"
+  - "12"
+  - "14"
 
 install:
   - npm install coveralls

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ class NodePinyin extends Pinyin {
 
 function segment(hans) {
   try {
-    jieba = jieba || require("nodejieba");
+    jieba = jieba || require("@node-rs/jieba");
   } catch (ex) {
     console.error();
     console.error("    Segment need nodejieba, please run '$ npm install nodejieba'.");
@@ -93,7 +93,7 @@ function segment(hans) {
   }
   // 词语拼音库。
   PHRASES_DICT = PHRASES_DICT || require("../data/phrases-dict");
-  return jieba.cutSmall(hans, 4);
+  return jieba.cut(hans, 4);
 }
 
 const pinyin = new NodePinyin(PINYIN_DICT);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "object-assign": "^4.0.1"
   },
   "optionalDependencies": {
-    "nodejieba": "^2.2.1"
+    "@node-rs/jieba": "^0.6.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
`@node-rs/jieba` is easy to install which no need `node-gyp, C++ toolchains` and without `postinstall scripts` which download binary files from Github release.

Also, better performnace.

### `@node-rs/jieba`

```
pinyin --segment 中文 x 359,323 ops/sec ±0.73% (98 runs sampled) memory usage: 136,351,744 bytes.
pinyin --segment --heteronym 中文 x 318,336 ops/sec ±1.78% (94 runs sampled) memory usage: 1,523,712 bytes.
pinyin --segment --heteronym --style NORMAL 中文 x 321,629 ops/sec ±1.28% (94 runs sampled) memory usage: 1,245,184 bytes.
```

### `nodejieba`
```
pinyin --segment 中文 x 340,823 ops/sec ±0.88% (95 runs sampled) memory usage: 249,540,608 bytes.
pinyin --segment --heteronym 中文 x 315,942 ops/sec ±1.14% (95 runs sampled) memory usage: 1,122,304 bytes.
pinyin --segment --heteronym --style NORMAL 中文 x 290,042 ops/sec ±2.11% (92 runs sampled) memory usage: 1,204,224 bytes.
```