### PR TITLE
增加了一个split_like的选项

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,11 @@ class NodePinyin extends Pinyin {
         }
 
       } else {
-        nohans += words;
+        if (options && options.split_like) {
+          pys.push([words])
+        }else{
+          nohans += words;
+        }
       }
     }
 


### PR DESCRIPTION
增加了一个split_like的选项，这样当解析含有标点符号的字符串时，比如
console.log(pinyin("黄鹤楼  [唐] 崔颢\r\n昔人已乘黄鹤去，此地空余黄鹤楼。",{segment: true, split_like: true}))
就会输出：
```
[
  [ 'huáng' ], [ 'hè' ],    [ 'lóu' ],
  [ ' ' ],     [ ' ' ],     [ '[' ],
  [ 'táng' ],  [ ']' ],     [ ' ' ],
  [ 'cuī' ],   [ 'hào' ],   [ '\r' ],
  [ '\n' ],    [ 'xī' ],    [ 'rén' ],
  [ 'yǐ' ],    [ 'chéng' ], [ 'huáng' ],
  [ 'hè' ],    [ 'qù' ],    [ '，' ],
  [ 'cǐ' ],    [ 'dì' ],    [ 'kòng' ],
  [ 'yú' ],    [ 'huáng' ], [ 'hè' ],
  [ 'lóu' ],   [ '。' ]
]
```
好处是可以与原始字符串split('')的结果进行一一对应，方便生成json。