### PR TITLE
新增紧凑输出方法

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,12 @@ class NodePinyin extends Pinyin {
       nohans = ""; // reset non-chinese words.
     }
 
+    Object.defineProperty(pys, "compact", {
+      value: util.compact.bind(this, pys),
+      enumerable: false,
+      configurable: false,
+    });
+
     return pys;
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,7 @@ const pinyin = new NodePinyin(PINYIN_DICT);
 
 module.exports = pinyin.convert.bind(pinyin);
 module.exports.compare = pinyin.compare.bind(pinyin);
+module.exports.compact = pinyin.compact.bind(pinyin);
 module.exports.STYLE_NORMAL = Pinyin.STYLE_NORMAL;
 module.exports.STYLE_TONE = Pinyin.STYLE_TONE;
 module.exports.STYLE_TONE2 = Pinyin.STYLE_TONE2;

--- a/lib/pinyin.js
+++ b/lib/pinyin.js
@@ -24,6 +24,7 @@ const INITIALS = "b,p,m,f,d,t,n,l,g,k,h,j,q,x,r,zh,ch,sh,z,c,s".split(",");
 const PHONETIC_SYMBOL = require("./phonetic-symbol");
 const RE_PHONETIC_SYMBOL = new RegExp("([" + Object.keys(PHONETIC_SYMBOL).join("") + "])", "g");
 const RE_TONE2 = /([aeoiuvnm])([0-4])$/;
+const util = require("./util");
 
 /*
  * 格式化拼音为声母（Initials）形式。
@@ -182,6 +183,10 @@ class Pinyin {
     const pinyinA = this.convert(hanA, DEFAULT_OPTIONS);
     const pinyinB = this.convert(hanB, DEFAULT_OPTIONS);
     return String(pinyinA).localeCompare(String(pinyinB));
+  }
+
+  compact(arr) {
+    return util.compact(arr);
   }
 
   static get STYLE_NORMAL () {

--- a/lib/pinyin.js
+++ b/lib/pinyin.js
@@ -84,6 +84,13 @@ class Pinyin {
       pys.push([nohans]);
       nohans = ""; // reset non-chinese words.
     }
+
+    Object.defineProperty(pys, "compact", {
+      value: util.compact.bind(this, pys),
+      enumerable: false,
+      configurable: false,
+    });
+
     return pys;
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,5 +45,43 @@ function combo(arr) {
   return result;
 }
 
+/**
+ * 组合两个拼音数组，形成一个新的二维数组
+ * @param {Array<String>} arr1 eg: ['hai', 'huan']
+ * @param {Array<String>} arr2 eg: ['qian']
+ * @returns 组合后的二维数组，eg: [ ['hai', 'qian'], ['huan', 'qian'] ]
+ */
+function compact2array(a1, a2) {
+  const result = [];
+  if (!a1.length) {
+    return a2;
+  }
+  if (!a2.length) {
+    return a1;
+  }
+  for (let i = 0, l = a1.length; i < l; i++) {
+    for (let j = 0, m = a2.length; j < m; j++) {
+      result.push(a1[i] + "," + a2[j]);
+    }
+  }
+  return result.map(item => item.split(","));
+}
+
+function compact(arr) {
+  if (arr.length === 0) {
+    return [];
+  }
+  if (arr.length === 1) {
+    return arr[0];
+  }
+  let result = compact2array(arr[0], arr[1]);
+  for (let i = 2, l = arr.length; i < l; i++) {
+    result = compact2array(result, arr[i]);
+  }
+  return result;
+}
+
 exports.combo2array = combo2array;
 exports.combo = combo;
+exports.compact2array = compact2array;
+exports.compact = compact;

--- a/lib/util.js
+++ b/lib/util.js
@@ -55,14 +55,11 @@ function compact2array(a1, a2) {
   if (!Array.isArray(a1) || !Array.isArray(a2)) {
     throw new Error("compact2array expect two array as parameters");
   }
-  if (!(a1.length || a2.length)) {
-    return [];
-  }
   if (!a1.length) {
-    return [a2];
+    a1 = [undefined];
   }
   if (!a2.length) {
-    return [a1];
+    a2 = [undefined];
   }
   const result = [];
   for (let i = 0, l = a1.length; i < l; i++) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -39,7 +39,7 @@ function combo(arr) {
     return arr[0];
   }
   let result = combo2array(arr[0], arr[1]);
-  for (let i = 2, l = arr.length; i < l; i++) {
+  for (let i = 2, l = arr.length; i < l; ++i) {
     result = combo2array(result, arr[i]);
   }
   return result;
@@ -53,11 +53,17 @@ function combo(arr) {
  */
 function compact2array(a1, a2) {
   const result = [];
+  if (!Array.isArray(a1) || !Array.isArray(a2)) {
+    throw new Error("compact2array expect two array as parameters");
+  }
+  if (!(a1.length || a2.length)) {
+    return [];
+  }
   if (!a1.length) {
-    return a2;
+    return [a2];
   }
   if (!a2.length) {
-    return a1;
+    return [a1];
   }
   for (let i = 0, l = a1.length; i < l; i++) {
     for (let j = 0, m = a2.length; j < m; j++) {
@@ -72,10 +78,10 @@ function compact(arr) {
     return [];
   }
   if (arr.length === 1) {
-    return arr[0];
+    return [arr[0]];
   }
   let result = compact2array(arr[0], arr[1]);
-  for (let i = 2, l = arr.length; i < l; i++) {
+  for (let i = 2, l = arr.length; i < l; ++i) {
     result = compact2array(result, arr[i]);
   }
   return result;

--- a/lib/util.js
+++ b/lib/util.js
@@ -47,12 +47,11 @@ function combo(arr) {
 
 /**
  * 组合两个拼音数组，形成一个新的二维数组
- * @param {Array<String>} arr1 eg: ['hai', 'huan']
+ * @param {string[]|string[][]} arr1 eg: ['hai', 'huan']
  * @param {Array<String>} arr2 eg: ['qian']
- * @returns 组合后的二维数组，eg: [ ['hai', 'qian'], ['huan', 'qian'] ]
+ * @returns {string[][]} 组合后的二维数组，eg: [ ['hai', 'qian'], ['huan', 'qian'] ]
  */
 function compact2array(a1, a2) {
-  const result = [];
   if (!Array.isArray(a1) || !Array.isArray(a2)) {
     throw new Error("compact2array expect two array as parameters");
   }
@@ -65,12 +64,17 @@ function compact2array(a1, a2) {
   if (!a2.length) {
     return [a1];
   }
+  const result = [];
   for (let i = 0, l = a1.length; i < l; i++) {
     for (let j = 0, m = a2.length; j < m; j++) {
-      result.push(a1[i] + "," + a2[j]);
+      if (Array.isArray(a1[i])) {
+        result.push([...a1[i], a2[j]]);
+      } else {
+        result.push([a1[i], a2[j]]);
+      }
     }
   }
-  return result.map(item => item.split(","));
+  return result;
 }
 
 function compact(arr) {

--- a/lib/web-pinyin.js
+++ b/lib/web-pinyin.js
@@ -28,6 +28,7 @@ const pinyin = new Pinyin(PINYIN_DICT);
 
 module.exports = pinyin.convert.bind(pinyin);
 module.exports.compare = pinyin.compare.bind(pinyin);
+module.exports.compact = pinyin.compact.bind(pinyin);
 module.exports.STYLE_NORMAL = Pinyin.STYLE_NORMAL;
 module.exports.STYLE_TONE = Pinyin.STYLE_TONE;
 module.exports.STYLE_TONE2 = Pinyin.STYLE_TONE2;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "doc:build": "dumi build",
     "doc:deploy": "npm run doc:build && cp CNAME docs-dist/dist && gh-pages -d docs-dist/dist",
     "lint": "eslint ./lib/ ./bin/ ./tests/",
+    "test-util": "mocha -R spec --timeout 5000 tests/util.test.js",
     "test-cli": "mocha -R spec --timeout 5000 tests/cli.test.js",
     "test-npm": "istanbul cover _mocha -- --harmony --reporter spec --timeout 2000 --inline-diffs ./tests/test.js",
     "benchmark": "node tests/benchmark.test.js",

--- a/tests/test.js
+++ b/tests/test.js
@@ -264,7 +264,10 @@ describe("pinyin", function() {
   for (var i = 0, han, opt, l = cases.length; i < l; i++) {
     han = cases[i][0];
     opt = cases[i][1];
-    for(var style in opt){
+    for(var style in opt) {
+      if (opt.hasOwnProperty(style)) {
+        return;
+      }
       makeTest(han, opt, style);
     }
   }
@@ -289,5 +292,25 @@ describe("pinyin group", function() {
     const han = "我都喜欢朝阳";
     const py = pinyin(han, {segment: true, group: true, heteronym: true});
     expect(py).to.eql([["wǒ"], ["dū", "dōu"], ["xǐhuān"], ["zhāoyáng", "cháoyáng"]]);
+  });
+});
+
+describe("pinyin compact", function() {
+  it("compact with heternonyms, normal style", function() {
+    const han = "还钱";
+    const py = pinyin(han, { style: pinyin.STYLE_NORMAL, segment: true, group: true, heteronym: true });
+    expect(pinyin.compact(py)).to.eql([["huan", "qian"], ["hai", "qian"]]);
+  });
+
+  it("compact with heternonyms, first letter", function() {
+    const han = "还钱";
+    const py = pinyin(han, { style: pinyin.STYLE_FIRST_LETTER, segment: true, group: false, heteronym: true });
+    expect(pinyin.compact(py)).to.eql([["h", "q"]]);
+  });
+
+  it("compact with heternonyms", function() {
+    const han = "还钱";
+    const py = pinyin(han, {segment: true, group: true, heteronym: true});
+    expect(pinyin.compact(py)).to.eql([["huán", "qián"], ["hái", "qián"]]);
   });
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -308,15 +308,21 @@ describe("pinyin compact", function() {
     expect(pinyin.compact(py)).to.eql([["huan", "qian"], ["hai", "qian"]]);
   });
 
-  it("compact with heternonyms, first letter", function() {
+  it("compact with heternonyms, first letter, group false", function() {
     const han = "还钱";
     const py = pinyin(han, { style: pinyin.STYLE_FIRST_LETTER, segment: true, group: false, heteronym: true });
     expect(pinyin.compact(py)).to.eql([["h", "q"]]);
   });
 
-  it("compact with heternonyms", function() {
+  it("compact with heternonyms, group true", function() {
     const han = "还钱";
     const py = pinyin(han, {segment: true, group: true, heteronym: true});
     expect(pinyin.compact(py)).to.eql([["huán", "qián"], ["hái", "qián"]]);
+  });
+
+  it("compact with heternonyms, many words", function() {
+    const han = "我们都爱朝阳";
+    const py = pinyin(han, { style: pinyin.STYLE_FIRST_LETTER, heteronym: true}).compact();
+    expect(py).to.eql([["w", "m", "d", "a", "z", "y"], ["w", "m", "d", "a", "c", "y"]]);
   });
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -265,9 +265,6 @@ describe("pinyin", function() {
     han = cases[i][0];
     opt = cases[i][1];
     for(var style in opt) {
-      if (opt.hasOwnProperty(style)) {
-        return;
-      }
       makeTest(han, opt, style);
     }
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -298,6 +298,12 @@ describe("pinyin group", function() {
 describe("pinyin compact", function() {
   it("compact with heternonyms, normal style", function() {
     const han = "还钱";
+    const py = pinyin(han, { style: pinyin.STYLE_NORMAL, segment: true, group: true, heteronym: true }).compact();
+    expect(py).to.eql([["huan", "qian"], ["hai", "qian"]]);
+  });
+
+  it("compact with heternonyms, normal style", function() {
+    const han = "还钱";
     const py = pinyin(han, { style: pinyin.STYLE_NORMAL, segment: true, group: true, heteronym: true });
     expect(pinyin.compact(py)).to.eql([["huan", "qian"], ["hai", "qian"]]);
   });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -135,6 +135,10 @@ describe("test/util.test.js", function() {
       expect(util.compact([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a", "1", "A"], ["a", "2", "A"], ["b", "1", "A"], ["b", "2", "A"]]);
     });
 
+    it("compact([[a,b],[1,2],[A]])", function() {
+      expect(util.compact([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a", "1", "A"], ["a", "2", "A"], ["b", "1", "A"], ["b", "2", "A"]]);
+    });
+
     it("compact([[a,b],[1,2],[A,B]])", function() {
       expect(util.compact([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a", "1", "A"], ["a", "1", "B"], ["a", "2", "A"], ["a", "2", "B"], ["b", "1", "A"], ["b", "1", "B"], ["b", "2", "A"], ["b", "2", "B"]]);
     });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -4,69 +4,69 @@ const expect = require("expect.js");
 const util = require("../lib/util");
 
 describe("test/util.test.js", function() {
-  // describe("combo2array", function() {
-  //   it("combo2array([], [])", function() {
-  //     expect(util.combo2array([], [])).to.eql([]);
-  //   });
+  describe("combo2array", function() {
+    it("combo2array([], [])", function() {
+      expect(util.combo2array([], [])).to.eql([]);
+    });
 
-  //   it("combo2array([a], [])", function() {
-  //     expect(util.combo2array(["a"], [])).to.eql(["a"]);
-  //   });
+    it("combo2array([a], [])", function() {
+      expect(util.combo2array(["a"], [])).to.eql(["a"]);
+    });
 
-  //   it("combo2array([], [1])", function() {
-  //     expect(util.combo2array([], ["1"])).to.eql(["1"]);
-  //   });
+    it("combo2array([], [1])", function() {
+      expect(util.combo2array([], ["1"])).to.eql(["1"]);
+    });
 
-  //   it("combo2array([a], [1])", function() {
-  //     expect(util.combo2array(["a"], ["1"])).to.eql(["a1"]);
-  //   });
+    it("combo2array([a], [1])", function() {
+      expect(util.combo2array(["a"], ["1"])).to.eql(["a1"]);
+    });
 
-  //   it("combo2array([a,b], [1])", function() {
-  //     expect(util.combo2array(["a", "b"], ["1"])).to.eql(["a1", "b1"]);
-  //   });
+    it("combo2array([a,b], [1])", function() {
+      expect(util.combo2array(["a", "b"], ["1"])).to.eql(["a1", "b1"]);
+    });
 
-  //   it("combo2array([a], [1,2])", function() {
-  //     expect(util.combo2array(["a"], ["1", "2"])).to.eql(["a1", "a2"]);
-  //   });
+    it("combo2array([a], [1,2])", function() {
+      expect(util.combo2array(["a"], ["1", "2"])).to.eql(["a1", "a2"]);
+    });
 
-  //   it("combo2array([a,b], [1,2])", function() {
-  //     expect(util.combo2array(["a", "b"], ["1", "2"])).to.eql(["a1", "a2", "b1", "b2"]);
-  //   });
+    it("combo2array([a,b], [1,2])", function() {
+      expect(util.combo2array(["a", "b"], ["1", "2"])).to.eql(["a1", "a2", "b1", "b2"]);
+    });
 
-  //   it("combo2array([a,b,c], [1,2,3])", function() {
-  //     expect(util.combo2array(["a", "b", "c"], ["1", "2", "3"])).to.eql(["a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"]);
-  //   });
-  // });
+    it("combo2array([a,b,c], [1,2,3])", function() {
+      expect(util.combo2array(["a", "b", "c"], ["1", "2", "3"])).to.eql(["a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"]);
+    });
+  });
 
-  // describe("combo", function() {
-  //   it("combo([])", function() {
-  //     expect(util.combo([])).to.eql([]);
-  //   });
+  describe("combo", function() {
+    it("combo([])", function() {
+      expect(util.combo([])).to.eql([]);
+    });
 
-  //   it("combo([[a]])", function() {
-  //     expect(util.combo([["a"]])).to.eql([["a"]]);
-  //   });
+    it("combo([[a]])", function() {
+      expect(util.combo([["a"]])).to.eql([["a"]]);
+    });
 
-  //   it("combo([[a,b]])", function() {
-  //     expect(util.combo([["a", "b"]])).to.eql([["a", "b"]]);
-  //   });
+    it("combo([[a,b]])", function() {
+      expect(util.combo([["a", "b"]])).to.eql([["a", "b"]]);
+    });
 
-  //   it("combo([[a,b],[1]])", function() {
-  //     expect(util.combo([["a", "b"], ["1"]])).to.eql([["a1", "b1"]]);
-  //   });
+    it("combo([[a,b],[1]])", function() {
+      expect(util.combo([["a", "b"], ["1"]])).to.eql([["a1", "b1"]]);
+    });
 
-  //   it("combo([[a,b],[1,2]])", function() {
-  //     expect(util.combo([["a", "b"], ["1", "2"]])).to.eql([["a1", "a2", "b1", "b2"]]);
-  //   });
+    it("combo([[a,b],[1,2]])", function() {
+      expect(util.combo([["a", "b"], ["1", "2"]])).to.eql([["a1", "a2", "b1", "b2"]]);
+    });
 
-  //   it("combo([[a,b],[1,2],[A]])", function() {
-  //     expect(util.combo([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a1A", "a2A", "b1A", "b2A"]]);
-  //   });
+    it("combo([[a,b],[1,2],[A]])", function() {
+      expect(util.combo([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a1A", "a2A", "b1A", "b2A"]]);
+    });
 
-  //   it("combo([[a,b],[1,2],[A,B]])", function() {
-  //     expect(util.combo([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a1A", "a1B", "a2A", "a2B", "b1A", "b1B", "b2A", "b2B"]]);
-  //   });
-  // });
+    it("combo([[a,b],[1,2],[A,B]])", function() {
+      expect(util.combo([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a1A", "a1B", "a2A", "a2B", "b1A", "b1B", "b2A", "b2B"]]);
+    });
+  });
 
   describe("compact2array", function() {
     it("compact2array([], [])", function() {

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -4,67 +4,139 @@ const expect = require("expect.js");
 const util = require("../lib/util");
 
 describe("test/util.test.js", function() {
-  describe("combo2array", function() {
-    it("combo2array([], [])", function() {
-      expect(util.combo2array([], [])).to.eql([]);
+  // describe("combo2array", function() {
+  //   it("combo2array([], [])", function() {
+  //     expect(util.combo2array([], [])).to.eql([]);
+  //   });
+
+  //   it("combo2array([a], [])", function() {
+  //     expect(util.combo2array(["a"], [])).to.eql(["a"]);
+  //   });
+
+  //   it("combo2array([], [1])", function() {
+  //     expect(util.combo2array([], ["1"])).to.eql(["1"]);
+  //   });
+
+  //   it("combo2array([a], [1])", function() {
+  //     expect(util.combo2array(["a"], ["1"])).to.eql(["a1"]);
+  //   });
+
+  //   it("combo2array([a,b], [1])", function() {
+  //     expect(util.combo2array(["a", "b"], ["1"])).to.eql(["a1", "b1"]);
+  //   });
+
+  //   it("combo2array([a], [1,2])", function() {
+  //     expect(util.combo2array(["a"], ["1", "2"])).to.eql(["a1", "a2"]);
+  //   });
+
+  //   it("combo2array([a,b], [1,2])", function() {
+  //     expect(util.combo2array(["a", "b"], ["1", "2"])).to.eql(["a1", "a2", "b1", "b2"]);
+  //   });
+
+  //   it("combo2array([a,b,c], [1,2,3])", function() {
+  //     expect(util.combo2array(["a", "b", "c"], ["1", "2", "3"])).to.eql(["a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"]);
+  //   });
+  // });
+
+  // describe("combo", function() {
+  //   it("combo([])", function() {
+  //     expect(util.combo([])).to.eql([]);
+  //   });
+
+  //   it("combo([[a]])", function() {
+  //     expect(util.combo([["a"]])).to.eql([["a"]]);
+  //   });
+
+  //   it("combo([[a,b]])", function() {
+  //     expect(util.combo([["a", "b"]])).to.eql([["a", "b"]]);
+  //   });
+
+  //   it("combo([[a,b],[1]])", function() {
+  //     expect(util.combo([["a", "b"], ["1"]])).to.eql([["a1", "b1"]]);
+  //   });
+
+  //   it("combo([[a,b],[1,2]])", function() {
+  //     expect(util.combo([["a", "b"], ["1", "2"]])).to.eql([["a1", "a2", "b1", "b2"]]);
+  //   });
+
+  //   it("combo([[a,b],[1,2],[A]])", function() {
+  //     expect(util.combo([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a1A", "a2A", "b1A", "b2A"]]);
+  //   });
+
+  //   it("combo([[a,b],[1,2],[A,B]])", function() {
+  //     expect(util.combo([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a1A", "a1B", "a2A", "a2B", "b1A", "b1B", "b2A", "b2B"]]);
+  //   });
+  // });
+
+  describe("compact2array", function() {
+    it("compact2array([], [])", function() {
+      expect(util.compact2array([], [])).to.eql([]);
     });
 
-    it("combo2array([a], [])", function() {
-      expect(util.combo2array(["a"], [])).to.eql(["a"]);
+    it("compact2array([a], [])", function() {
+      expect(util.compact2array(["a"], [])).to.eql([["a"]]);
     });
 
-    it("combo2array([], [1])", function() {
-      expect(util.combo2array([], ["1"])).to.eql(["1"]);
+    it("compact2array([], [1])", function() {
+      expect(util.compact2array([], ["1"])).to.eql([["1"]]);
     });
 
-    it("combo2array([a], [1])", function() {
-      expect(util.combo2array(["a"], ["1"])).to.eql(["a1"]);
+    it("compact2array([a, b, c], [])", function() {
+      expect(util.compact2array(["a", "b", "c"], [])).to.eql([["a", "b", "c"]]);
     });
 
-    it("combo2array([a,b], [1])", function() {
-      expect(util.combo2array(["a", "b"], ["1"])).to.eql(["a1", "b1"]);
+    it("compact2array([], [a, b, c])", function() {
+      expect(util.compact2array([], ["a", "b", "c"])).to.eql([["a", "b", "c"]]);
     });
 
-    it("combo2array([a], [1,2])", function() {
-      expect(util.combo2array(["a"], ["1", "2"])).to.eql(["a1", "a2"]);
+    it("compact2array([a], [1])", function() {
+      expect(util.compact2array(["a"], ["1"])).to.eql([["a", "1"]]);
     });
 
-    it("combo2array([a,b], [1,2])", function() {
-      expect(util.combo2array(["a", "b"], ["1", "2"])).to.eql(["a1", "a2", "b1", "b2"]);
+    it("compact2array([a,b], [1])", function() {
+      expect(util.compact2array(["a", "b"], ["1"])).to.eql([["a", "1"], ["b", "1"]]);
     });
 
-    it("combo2array([a,b,c], [1,2,3])", function() {
-      expect(util.combo2array(["a", "b", "c"], ["1", "2", "3"])).to.eql(["a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"]);
+    it("compact2array([a], [1,2])", function() {
+      expect(util.compact2array(["a"], ["1", "2"])).to.eql([["a", "1"], ["a", "2"]]);
+    });
+
+    it("compact2array([a,b], [1,2])", function() {
+      expect(util.compact2array(["a", "b"], ["1", "2"])).to.eql([["a", "1"], ["a", "2"], ["b", "1"], ["b", "2"]]);
+    });
+
+    it("compact2array([a,b,c], [1,2,3])", function() {
+      expect(util.compact2array(["a", "b", "c"], ["1", "2", "3"])).to.eql([["a", "1"], ["a", "2"], ["a", "3"], ["b", "1"], ["b", "2"], ["b", "3"], ["c", "1"], ["c", "2"], ["c", "3"]]);
     });
   });
 
-  describe("combo", function() {
-    it("combo([])", function() {
-      expect(util.combo([])).to.eql([]);
+  describe("compact", function() {
+    it("compact([])", function() {
+      expect(util.compact([])).to.eql([]);
     });
 
-    it("combo([[a]])", function() {
-      expect(util.combo([["a"]])).to.eql([["a"]]);
+    it("compact([[a]])", function() {
+      expect(util.compact([["a"]])).to.eql([["a"]]);
     });
 
-    it("combo([[a,b]])", function() {
-      expect(util.combo([["a", "b"]])).to.eql([["a", "b"]]);
+    it("compact([[a,b]])", function() {
+      expect(util.compact([["a", "b"]])).to.eql([["a", "b"]]);
     });
 
-    it("combo([[a,b],[1]])", function() {
-      expect(util.combo([["a", "b"], ["1"]])).to.eql([["a1", "b1"]]);
+    it("compact([[a,b],[1]])", function() {
+      expect(util.compact([["a", "b"], ["1"]])).to.eql([["a", "1"], ["b", "1"]]);
     });
 
-    it("combo([[a,b],[1,2]])", function() {
-      expect(util.combo([["a", "b"], ["1", "2"]])).to.eql([["a1", "a2", "b1", "b2"]]);
+    it("compact([[a,b],[1,2]])", function() {
+      expect(util.compact([["a", "b"], ["1", "2"]])).to.eql([["a", "1"], ["a", "2"], ["b", "1"], ["b", "2"]]);
     });
 
-    it("combo([[a,b],[1,2],[A]])", function() {
-      expect(util.combo([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a1A", "a2A", "b1A", "b2A"]]);
+    it("compact([[a,b],[1,2],[A]])", function() {
+      expect(util.compact([["a", "b"], ["1", "2"], ["A"]])).to.eql([["a", "1", "A"], ["a", "2", "A"], ["b", "1", "A"], ["b", "2", "A"]]);
     });
 
-    it("combo([[a,b],[1,2],[A,B]])", function() {
-      expect(util.combo([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a1A", "a1B", "a2A", "a2B", "b1A", "b1B", "b2A", "b2B"]]);
+    it("compact([[a,b],[1,2],[A,B]])", function() {
+      expect(util.compact([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a", "1", "A"], ["a", "1", "B"], ["a", "2", "A"], ["a", "2", "B"], ["b", "1", "A"], ["b", "1", "B"], ["b", "2", "A"], ["b", "2", "B"]]);
     });
   });
 });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -70,23 +70,23 @@ describe("test/util.test.js", function() {
 
   describe("compact2array", function() {
     it("compact2array([], [])", function() {
-      expect(util.compact2array([], [])).to.eql([]);
+      expect(util.compact2array([], [])).to.eql([[undefined, undefined]]);
     });
 
     it("compact2array([a], [])", function() {
-      expect(util.compact2array(["a"], [])).to.eql([["a"]]);
+      expect(util.compact2array(["a"], [])).to.eql([["a", undefined]]);
     });
 
     it("compact2array([], [1])", function() {
-      expect(util.compact2array([], ["1"])).to.eql([["1"]]);
+      expect(util.compact2array([], ["1"])).to.eql([[undefined, "1"]]);
     });
 
     it("compact2array([a, b, c], [])", function() {
-      expect(util.compact2array(["a", "b", "c"], [])).to.eql([["a", "b", "c"]]);
+      expect(util.compact2array(["a", "b", "c"], [])).to.eql([["a", undefined], ["b", undefined], ["c", undefined]]);
     });
 
     it("compact2array([], [a, b, c])", function() {
-      expect(util.compact2array([], ["a", "b", "c"])).to.eql([["a", "b", "c"]]);
+      expect(util.compact2array([], ["a", "b", "c"])).to.eql([[undefined, "a"], [undefined, "b"], [undefined, "c"]]);
     });
 
     it("compact2array([a], [1])", function() {
@@ -141,6 +141,10 @@ describe("test/util.test.js", function() {
 
     it("compact([[a,b],[1,2],[A,B]])", function() {
       expect(util.compact([["a", "b"], ["1", "2"], ["A", "B"]])).to.eql([["a", "1", "A"], ["a", "1", "B"], ["a", "2", "A"], ["a", "2", "B"], ["b", "1", "A"], ["b", "1", "B"], ["b", "2", "A"], ["b", "2", "B"]]);
+    });
+
+    it("compact([[ni],[],[hao, hai]])", function() {
+      expect(util.compact([["ni"], [], ["hao", "hai"]])).to.eql([["ni", undefined, "hao"], ["ni", undefined, "hai"]]);
     });
   });
 });


### PR DESCRIPTION
:sparkles: 新增紧凑输出

使用方法

```js
pinyin("还钱", { 
  style: pinyin.STYLE_NORMAL, 
  segment: true, 
  group: true, 
  heteronym: true,
}).compact();
// output: [['huan', 'qian'], ['hai', 'qian']]
```

或

```js
const py = pinyin("还钱", { 
  style: pinyin.STYLE_NORMAL, 
  segment: true, 
  group: true, 
  heteronym: true,
});
pinyin.compact(py)

// output: [['huan', 'qian'], ['hai', 'qian']]
```