### PR TITLE
doc: fix the link of dist

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -200,7 +200,7 @@ npm test
 
 如果你坚持在客户端使用，你可以考虑使用 [Webpack](http://webpack.github.io/) + [Babel](http://babeljs.io/) 来转换成低端浏览器的可执行代码。
 
-实在不想折腾，可以试试 https://github.com/hotoo/pinyin/tree/gh-pages/dist
+实在不想折腾，可以试试 https://github.com/hotoo/pinyin/tree/ddf628f397b03c405bddb1ce498f815561e7c39c/dist
 
 ### 为什么没有 `y`, `w`, `yu` 几个声母？
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ npm test
 
 如果你坚持在客户端使用，你可以考虑使用 [Webpack](http://webpack.github.io/) + [Babel](http://babeljs.io/) 来转换成低端浏览器的可执行代码。
 
-实在不想折腾，可以试试 https://github.com/hotoo/pinyin/tree/gh-pages/dist
+实在不想折腾，可以试试 https://github.com/hotoo/pinyin/tree/ddf628f397b03c405bddb1ce498f815561e7c39c/dist
 
 ### 为什么没有 `y`, `w`, `yu` 几个声母？
 


### PR DESCRIPTION
The link `https://github.com/hotoo/pinyin/tree/gh-pages/dist` disappeared.
I have found the latest commit of `gh-pages` branch that the folder is existed.
> https://github.com/hotoo/pinyin/tree/ddf628f397b03c405bddb1ce498f815561e7c39c/dist