### PR TITLE
fix: compare() 未处理多音调汉字的正确排序权重（如“暗”错排在“安”之前），建议改用 STYLE_TONE2 进行底层比较

### DIFF
--- a/packages/pinyin/src/PinyinBase.ts
+++ b/packages/pinyin/src/PinyinBase.ts
@@ -276,8 +276,8 @@ export default class PinyinBase {
    * @return {Number} 返回 -1，0，或 1。
    */
   compare(hanA: string, hanB: string): number {
-    const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 }).map(p => p[0]).join('');
-    const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 }).map(p => p[0]).join('');
+    const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 });
+    const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 });
     return pinyinA.localeCompare(pinyinB);
   }
 

--- a/packages/pinyin/src/PinyinBase.ts
+++ b/packages/pinyin/src/PinyinBase.ts
@@ -276,9 +276,9 @@ export default class PinyinBase {
    * @return {Number} 返回 -1，0，或 1。
    */
   compare(hanA: string, hanB: string): number {
-    const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 });
-    const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 });
-    return String(pinyinA).localeCompare(String(pinyinB));
+    const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 }).map(p => p[0]).join('');
+    const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 }).map(p => p[0]).join('');
+    return pinyinA.localeCompare(pinyinB);
   }
 
   compact(pys: string[][]): string[][] {

--- a/packages/pinyin/src/PinyinBase.ts
+++ b/packages/pinyin/src/PinyinBase.ts
@@ -278,7 +278,7 @@ export default class PinyinBase {
   compare(hanA: string, hanB: string): number {
     const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 });
     const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 });
-    return pinyinA.localeCompare(pinyinB);
+    return String(pinyinA).localeCompare(String(pinyinB));
   }
 
   compact(pys: string[][]): string[][] {

--- a/packages/pinyin/src/PinyinBase.ts
+++ b/packages/pinyin/src/PinyinBase.ts
@@ -276,8 +276,8 @@ export default class PinyinBase {
    * @return {Number} 返回 -1，0，或 1。
    */
   compare(hanA: string, hanB: string): number {
-    const pinyinA = this.pinyin(hanA);
-    const pinyinB = this.pinyin(hanB);
+    const pinyinA = this.pinyin(hanA, { style: ENUM_PINYIN_STYLE.TONE2 });
+    const pinyinB = this.pinyin(hanB, { style: ENUM_PINYIN_STYLE.TONE2 });
     return String(pinyinA).localeCompare(String(pinyinB));
   }
 

--- a/packages/pinyin/test/test.ts
+++ b/packages/pinyin/test/test.ts
@@ -367,6 +367,12 @@ describe("pinyin.compare", function() {
     const sortedData = data.sort(compare);
     expect(sortedData).toEqual("排我序要".split(""));
   });
+
+  it("同音节不同声调排序", function() {
+    const data = "马骂妈麻".split("");
+    const sortedData = data.sort(compare);
+    expect(sortedData).toEqual("妈麻马骂".split(""));
+  });
 });
 
 describe("pinyin group", function() {


### PR DESCRIPTION
在对中文数据进行排序时，我发现 `pinyin.compare` 存在同音不同调汉字的排序乱序问题。例如第四声的“暗（àn）”被排在了第一声的“安（ān）”前面。

### 复现
```javascript
import { pinyin } from "pinyin";
const data = ["安卡", "暗黑"];
const sortedData = data.sort(pinyin.compare);
console.log(sortedData); 
// 实际输出: [ '暗黑', '安卡' ] （错误）
// 期望输出: [ '安卡', '暗黑' ] （ān < àn）
```

### 分析
查看源码发现，`compare` 方法是对带有变音符号的字符串直接执行了 `localeCompare`：
```javascript
return String(pinyinA).localeCompare(String(pinyinB));
```
JS 原生排序变音符号时基于其 Unicode 编码进行排序，第四声 `à` 的编码（U+00E0）小于第一声 `ā` 的编码（U+0101），导致了排序颠倒（同理，“翅 chì”也会错排在“齿 chǐ”之前）。

### 修复
最健壮的做法是：内部比较时使用 **`STYLE_TONE2`（数字拼音放末尾，如 `an1`, `an4`）** 进行比较。
*   利用数字 ASCII (48-57) 永远小于字母 ASCII (97-122) 的特性，当比较 `ban4` 和 `bang1` 时，`4` 遇到 `g`，能自动确保 `ban` 排在 `bang` 之前。
*   同时，当字母完全相同时，如 `an1` 和 `an4`，`1 < 4` 也能保证声调排序正确。